### PR TITLE
  Apparently a bug in the socket.sendall calls 

### DIFF
--- a/ipi/interfaces/sockets.py
+++ b/ipi/interfaces/sockets.py
@@ -274,10 +274,10 @@ class DriverSocket(socket.socket):
       if (self.status & Status.Ready):
          try:
             self.sendall(Message("posdata"))
-            self.sendall(h_ih[0]) #, 9*8)
-            self.sendall(h_ih[1]) #, 9*8)
+            self.sendall(h_ih[0]) 
+            self.sendall(h_ih[1]) 
             self.sendall(np.int32(len(pos)/3))
-            self.sendall(pos)# , len(pos)*8)
+            self.sendall(pos)
          except:
             self.poll()
             return


### PR DESCRIPTION
```
Apparently a bug in the socket.sendall calls  that
```

  was being ignored by linux machines, but not by mac
  platforms. i-PI was not able to pass information about
  the cell and other things when the sendall call had two
  arguments (instead of 1). It now works on all mac machines I have access to.
