### PR TITLE
Fixed atoms constraints

### DIFF
--- a/ipi/engine/properties.py
+++ b/ipi/engine/properties.py
@@ -537,17 +537,19 @@ class Properties(dobject):
             for. If not, then the simulation temperature.
       """
 
+      if len(self.ensemble.fixatoms)>0:
+         mdof = len(self.ensemble.fixatoms)*3
+         if bead == "" and nm == "":
+            mdof*=self.beads.nbeads            
       if self.ensemble.fixcom:
          if bead == "" and nm == "":
-            mdof = 3
+            mdof += 3
          elif nm != "" and nm == "0":   # the centroid has 100% of the COM removal
-            mdof = 3
+            mdof += 3
          elif nm != "" :
-            mdof = 0
+            mdof += 0
          else:
-            mdof = 3.0/ float(self.beads.nbeads)  # spreads COM removal over the beads
-      else:
-         mdof = 0
+            mdof += 3.0/ float(self.beads.nbeads)  # spreads COM removal over the beads
 
       kemd, ncount = self.get_kinmd(atom, bead, nm, return_count=True)
 

--- a/ipi/inputs/ensembles.py
+++ b/ipi/inputs/ensembles.py
@@ -91,6 +91,9 @@ class InputEnsemble(Input):
            "fixcom": (InputValue, {"dtype"           : bool,
                                    "default"         : True,
                                    "help"            : "This describes whether the centre of mass of the particles is fixed."}),
+           "fixatoms" : (InputArray, {"dtype"        : int,
+                                    "default"      : np.zeros(0,int),
+                                    "help"         : "Indices of the atmoms that should be held fixed."}),
            "replay_file": (InputInitFile, {"default" : input_default(factory=ipi.engine.initializer.InitBase),
                            "help"            : "This describes the location to read a trajectory file from."})
          }
@@ -131,6 +134,7 @@ class InputEnsemble(Input):
       if tens > 1:
          self.thermostat.store(ens.thermostat)
          self.fixcom.store(ens.fixcom)
+         self.fixatoms.store(ens.fixatoms)
          self.eens.store(ens.eens)
       if tens == 3:
          self.barostat.store(ens.barostat)
@@ -151,22 +155,22 @@ class InputEnsemble(Input):
 
       if self.mode.fetch() == "nve" :
          ens = NVEEnsemble(dt=self.timestep.fetch(),
-            temp=self.temperature.fetch(), fixcom=self.fixcom.fetch(), eens=self.eens.fetch())
+            temp=self.temperature.fetch(), fixcom=self.fixcom.fetch(), eens=self.eens.fetch(), fixatoms=self.fixatoms.fetch())
       elif self.mode.fetch() == "nvt" :
          ens = NVTEnsemble(dt=self.timestep.fetch(),
-            temp=self.temperature.fetch(), thermostat=self.thermostat.fetch(), fixcom=self.fixcom.fetch(), eens=self.eens.fetch())
+            temp=self.temperature.fetch(), thermostat=self.thermostat.fetch(), fixcom=self.fixcom.fetch(), eens=self.eens.fetch(), fixatoms=self.fixatoms.fetch())
       elif self.mode.fetch() == "npt" :
          ens = NPTEnsemble(dt=self.timestep.fetch(),
-            temp=self.temperature.fetch(), thermostat=self.thermostat.fetch(), fixcom=self.fixcom.fetch(), eens=self.eens.fetch(),
+            temp=self.temperature.fetch(), thermostat=self.thermostat.fetch(), fixcom=self.fixcom.fetch(), eens=self.eens.fetch(), fixatoms=self.fixatoms.fetch(),
                   pext=self.pressure.fetch(), barostat=self.barostat.fetch() )
       elif self.mode.fetch() == "nst" :
          ens = NSTEnsemble(dt=self.timestep.fetch(),
-                           temp=self.temperature.fetch(), thermostat=self.thermostat.fetch(), fixcom=self.fixcom.fetch(), eens=self.eens.fetch(),
+                           temp=self.temperature.fetch(), thermostat=self.thermostat.fetch(), fixcom=self.fixcom.fetch(), eens=self.eens.fetch(), fixatoms=self.fixatoms.fetch(),
                            stressext=self.stress.fetch().reshape((3,3)), # casts into a 3x3 tensor
                            barostat=self.barostat.fetch() )
       elif self.mode.fetch() == "replay":
          ens = ReplayEnsemble(dt=self.timestep.fetch(),
-            temp=self.temperature.fetch(),fixcom=False, eens=self.eens.fetch() ,intraj=self.replay_file.fetch() )
+            temp=self.temperature.fetch(),fixcom=False, eens=self.eens.fetch(), fixatoms=None, intraj=self.replay_file.fetch() )
       else:
          raise ValueError("'" + self.mode.fetch() + "' is not a supported ensemble mode.")
 


### PR DESCRIPTION
Often people want to keep some atoms in the simulation fixed. This is a very crude implementation of a "fixatoms" keyword, that should make it possible to fix the coordinates of some atoms in the simulation. 
See if this interests any of you, and if you think there should be more features included. For the moment, I push it here since someone I know needs this.
