### PR TITLE
Fix the hashbang

### DIFF
--- a/i-pi
+++ b/i-pi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """Main script from which the simulation is run.
 


### PR DESCRIPTION
The Python interpreter path really should not be hard coded. This causes problems with non-standard locations, for example Python from modules on clusters.
