### PR TITLE
Always use new-style classes

### DIFF
--- a/ipi/interfaces/sockets.py
+++ b/ipi/interfaces/sockets.py
@@ -75,7 +75,7 @@ class InvalidStatus(Exception):
 
    pass
 
-class Status:
+class Status(object):
    """Simple class used to keep track of the status of the client.
 
    Uses bitwise or to give combinations of different status options.
@@ -380,7 +380,7 @@ class Driver(DriverSocket):
 
       if self.status & Status.NeedsInit:
          try:
-            self.sendall(Message("init")) 
+            self.sendall(Message("init"))
             self.sendall(np.int32(rid))
             self.sendall(np.int32(len(pars)))
             self.sendall(pars)
@@ -565,7 +565,7 @@ class InterfaceSocket(object):
       # flush it all down the drain
       self.clients = []
       self.jobs = []
- 
+
       try:
          self.server.shutdown(socket.SHUT_RDWR)
          self.server.close()

--- a/ipi/utils/nmtransform.py
+++ b/ipi/utils/nmtransform.py
@@ -9,7 +9,7 @@ the Free Software Foundation, either version 3 of the License, or
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
@@ -93,7 +93,7 @@ def mk_rs_matrix(nb1, nb2):
       return mk_rs_matrix(nb2, nb1).T*(float(nb2)/float(nb1))
 
 
-class nm_trans:
+class nm_trans(object):
    """Helper class to perform beads <--> normal modes transformation.
 
    Attributes:
@@ -132,7 +132,7 @@ class nm_trans:
       return np.dot(self._nm2b,q)
 
 
-class nm_rescale:
+class nm_rescale(object):
    """Helper class to rescale a ring polymer between different number of beads.
 
    Attributes:
@@ -173,7 +173,7 @@ class nm_rescale:
 
 
 
-class nm_fft:
+class nm_fft(object):
    """Helper class to perform beads <--> normal modes transformation
       using Fast Fourier transforms.
 

--- a/ipi/utils/units.py
+++ b/ipi/utils/units.py
@@ -9,7 +9,7 @@ the Free Software Foundation, either version 3 of the License, or
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
@@ -29,7 +29,7 @@ from ipi.utils.messages import verbosity, info
 __all__ = ['Constants', 'Elements', 'unit_to_internal', 'unit_to_user']
 
 
-class Constants:
+class Constants(object):
    """Class whose members are fundamental constants.
 
    Attributes:


### PR DESCRIPTION
There was a couple of places where old-style classes were used. We should always use new-style classes.

https://docs.python.org/2/reference/datamodel.html#new-style-and-classic-classes

I found these with `$ grep -r '^class' --include '*.py' . | grep -v '('`. If there are other cases that this does not show, I have missed them.
