### PR TITLE
Make unit lookup case insensitive

### DIFF
--- a/ipi/tests/test_units.py
+++ b/ipi/tests/test_units.py
@@ -1,0 +1,14 @@
+"""Tests unit conversion."""
+
+# This file is part of i-PI.
+# i-PI Copyright (C) 2014-2015 i-PI developers
+# See the "licenses" directory for full license information.
+
+
+from ipi.utils import units
+
+
+def test_case_insensitive():
+
+    angstrom = units.unit_to_internal('length', 'angstrom', 1.0)
+    Angstrom = units.unit_to_internal('length', 'Angstrom', 1.0)

--- a/ipi/utils/units.py
+++ b/ipi/utils/units.py
@@ -324,10 +324,10 @@ def unit_to_internal(family, unit, number):
 
    if not prefix in UnitPrefix:
       raise TypeError(prefix + " is not a valid unit prefix.")
-   if not base in UnitMap[family]:
+   if not base.lower() in UnitMap[family]:
       raise TypeError(base + " is an undefined unit for kind " + family + ".")
 
-   return number*UnitMap[family][base]*UnitPrefix[prefix]
+   return number*UnitMap[family][base.lower()]*UnitPrefix[prefix]
 
 def unit_to_user(family, unit, number):
    """Converts a number of given dimensions from internal to user units.


### PR DESCRIPTION
This small update makes unit lookup case insensitive so that users can use all lowercase, the actual capitalization of unit names, or aNy OtHeR convention they like.
