### PR TITLE
Do not hard code Python interpreter in executables

### DIFF
--- a/tools/py/getproperty.py
+++ b/tools/py/getproperty.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 """ getproperty.py
 
 Parses a property output file and - if present - outputs the column(s)
@@ -10,10 +11,12 @@ Syntax:
    geproperty.py propertyfile propertyname [skip]
 """
 
+
 import sys
 import re
 from ipi.utils.messages import warning
 from ipi.engine.outputs import *
+
 
 def main(inputfile, propertyname="potential", skip="0"):
    skip = int(skip)
@@ -49,6 +52,7 @@ def main(inputfile, propertyname="potential", skip="0"):
          step+=1
       except EOFError:
          break
+
 
 if __name__ == '__main__':
    main(*sys.argv[1:])

--- a/tools/py/kinetic2tag.py
+++ b/tools/py/kinetic2tag.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 """ kinetic2tag.py
 
 Computes the Transient Anisotropic Gaussian (TAG) approximation
@@ -14,12 +15,14 @@ Syntax:
    kinetic2tag.py prefix lag
 """
 
+
 import numpy as np
 
 import sys
 from ipi.utils.io import read_file
 from ipi.utils.depend import *
 from ipi.utils.units import *
+
 
 def main(prefix, lag):
 
@@ -63,7 +66,7 @@ def main(prefix, lag):
          mkt[:]=0.0; tw=0.0
          for j in range(cbuf):
             w=1.0-np.abs(j-lag)*1.0/lag;
-            mkt+=w*ktbuf[(ifr-j)%cbuf]; 
+            mkt+=w*ktbuf[(ifr-j)%cbuf];
             tw+=w;
          mkt*=1.0/tw
 
@@ -78,6 +81,7 @@ def main(prefix, lag):
             otag.write("%6s  %15.7e  %15.7e  %15.7e\n" % (tk.names[i], mea[i,0], mea[i,1],mea[i,2]))
 
       ifr+=1
+
 
 if __name__ == '__main__':
    main(*sys.argv[1:])

--- a/tools/py/mergebeadspdb.py
+++ b/tools/py/mergebeadspdb.py
@@ -1,7 +1,8 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 """ mergebeadspdb.py
 
-Reads positions of individual beads from an i-PI run and 
+Reads positions of individual beads from an i-PI run and
 assemles them in a pdb describing the ring polymer connectivity.
 
 Assumes the input files are in pdb format names prefix.pos_*.pdb.
@@ -10,6 +11,7 @@ Syntax:
    mergebeadspdb.py prefix
 """
 
+
 import numpy as np
 import sys, glob
 from ipi.utils.io import read_file, print_file_path
@@ -17,6 +19,7 @@ from ipi.engine.beads import Beads
 from ipi.engine.cell import Cell
 from ipi.utils.depend import *
 from ipi.utils.units import *
+
 
 def main(prefix):
 

--- a/tools/py/parasort.py
+++ b/tools/py/parasort.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 """ parasort.py
 
 Relies on the infrastructure of i-pi, so the ipi package should
@@ -18,6 +19,7 @@ data for replica 'index'.
 Syntax:
    parasort.py inputfile.xml
 """
+
 
 import sys
 import numpy as np
@@ -157,6 +159,7 @@ def main(inputfile, prefix="PT"):
                      traj[irep[isys]]["ofile"].write(''.join(ibuffer))
       except EOFError:
          break
+
 
 if __name__ == '__main__':
    main(*sys.argv[1:])

--- a/tools/py/paraweights.py
+++ b/tools/py/paraweights.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 """ paraweights.py
 
 Relies on the infrastructure of i-pi, so the ipi package should
@@ -6,12 +7,12 @@ be installed in the Python module directory, or the i-pi
 main directory must be added to the PYTHONPATH environment variable.
 
 Post-processes the output of a parallel-tempering simulation and
-computes - for each output file that contains potential energy 
-information - the log-weights that should be given to each 
-line to re-weight the ensemble at a given target temperature. 
+computes - for each output file that contains potential energy
+information - the log-weights that should be given to each
+line to re-weight the ensemble at a given target temperature.
 For each file, it also prints out the "global" weighing factor that
 should be used to combine different PT replicas, based on a simple
-estimate of the error based on 
+estimate of the error based on
 Ceriotti, Brain, Riordan, Manolopoulos, Proc. Royal Soc. A 468 (2011)
 and the assumption that the observable and the weight are un-correlated.
 In computing the global weight, by default a certain number of steps
@@ -21,11 +22,12 @@ It should be run in the same dyrectory as where i-pi was (or is being)
 run, and simply fetches all information from the simulation input file.
 Will create a series of (prefix)index_* files, each corresponding to the
 data for replica 'index', and a (prefix)WEIGHTS file containing the
-trajectory weights. 
+trajectory weights.
 
 Syntax:
    paraweights.py inputfile.xml [prefix] [temperature(K)] [skip]
 """
+
 
 import sys
 import re
@@ -42,8 +44,8 @@ def main(inputfile, prefix="PTW-", ttemp="300.0", skip="2000"):
    txtemp = ttemp
    ttemp = unit_to_internal("energy","kelvin",float(ttemp))
    skip = int(skip)
-   
-   # opens & parses the input file   
+
+   # opens & parses the input file
    ifile = open(inputfile,"r")
    verbosity.level="quiet"
    verbosity.lock = True
@@ -54,7 +56,7 @@ def main(inputfile, prefix="PTW-", ttemp="300.0", skip="2000"):
    isimul.parse(xmlrestart.fields[0][1])
    verbosity.level="quiet"
    banner()
-   print "# Printing out temperature re-weighing factors for a parallel tempering simulation"   
+   print "# Printing out temperature re-weighing factors for a parallel tempering simulation"
    simul = isimul.fetch()
 
    if simul.mode != "paratemp":
@@ -81,23 +83,23 @@ def main(inputfile, prefix="PTW-", ttemp="300.0", skip="2000"):
                            "ifile" : open(filename, "r"), "ofile" : None
              } )
             isys+=1
-         lprop.append(nprop)         
+         lprop.append(nprop)
 
    ptfile=open("PARATEMP", "r")
 
-   # these are variables used to compute the weighting factors 
+   # these are variables used to compute the weighting factors
    tprops=[]
    vfields=[]
    refpots=[]
    vunits=[]
    nw = []
-   tw = [] 
+   tw = []
    tw2 = []
-   
+
    repot = re.compile(' ([0-9]*) *--> potential')
    reunit = re.compile('{(.*)}')
-   
- 
+
+
    # now reads files one frame at a time, and re-direct output to the appropriate location
    irep = np.zeros(nsys,int)
    while True:
@@ -118,7 +120,7 @@ def main(inputfile, prefix="PTW-", ttemp="300.0", skip="2000"):
                if step % sprop["stride"] == 0: # property transfer
                   iline = sprop["ifile"].readline()
                   if len(iline)==0: raise EOFError
-                  while iline[0] == "#":  # fast forward if line is a comment 
+                  while iline[0] == "#":  # fast forward if line is a comment
                      # checks if we have one single file with potential energies
                      rm=repot.search(iline)
                      if not (rm is None) and not (prop in tprops):
@@ -133,9 +135,9 @@ def main(inputfile, prefix="PTW-", ttemp="300.0", skip="2000"):
                         tw2.append(np.zeros(nsys))
                         rm=reunit.search(iline)
                         if rm: vunits.append(rm.group(1))
-                        else: vunits.append("atomic_unit")                              
-                     iline = sprop["ifile"].readline()                     
-                  if prop in tprops: # do temperature weighing    
+                        else: vunits.append("atomic_unit")
+                     iline = sprop["ifile"].readline()
+                  if prop in tprops: # do temperature weighing
                      pot = unit_to_internal("energy", vunits[wk],float(iline.split()[vfields[wk]]))
                      ir = irep[isys]
                      if (nw[wk][ir]==0):
@@ -148,7 +150,7 @@ def main(inputfile, prefix="PTW-", ttemp="300.0", skip="2000"):
                            tw2[wk][ir] = lw
                         else:
                            tw[wk][ir] = logsumlog((tw[wk][ir],1),(lw,1))[0]
-                           tw2[wk][ir] = logsumlog((tw2[wk][ir],1),(2*lw,1))[0]                     
+                           tw2[wk][ir] = logsumlog((tw2[wk][ir],1),(2*lw,1))[0]
                         nw[wk][ir] += 1
                      prop[ir]["ofile"].write("%15.7e\n" %(lw))
                      if isys == nsys-1: wk+=1
@@ -159,13 +161,14 @@ def main(inputfile, prefix="PTW-", ttemp="300.0", skip="2000"):
          fpw.write("# Global trajectory weights for temperature %s K\n" % (txtemp) )
          fpw.write("# Please cite M. Ceriotti, G. A. Brain, O. Riordan, D.E. Manolopoulos, "+
                    "The inefficiency of re-weighted sampling and the curse of system size in high-order path integration. "+
-                   "Proceedings of the Royal Society A, 468(2137), 2-17  (2011) \n" )      
+                   "Proceedings of the Royal Society A, 468(2137), 2-17  (2011) \n" )
          for prop in lprop:
             if prop in tprops:
                for ir in range(nsys):
                   fpw.write("%s   %15.7e \n" % (prop[ir]["ofilename"], 1.0/(np.exp(tw2[wk][ir]-2*tw[wk][ir])*nw[wk][ir])  )  )
                wk+=1
          break
+
 
 if __name__ == '__main__':
    main(*sys.argv[1:])

--- a/tools/py/pos2centroid.py
+++ b/tools/py/pos2centroid.py
@@ -1,7 +1,8 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 """ pos2centroid.py
 
-Reads positions of individual beads from an i-PI run and 
+Reads positions of individual beads from an i-PI run and
 assemles them in a pdb describing the ring polymer connectivity.
 
 Assumes the input files are in pdb format names prefix.pos_*.pdb.
@@ -9,6 +10,7 @@ Assumes the input files are in pdb format names prefix.pos_*.pdb.
 Syntax:
    mergebeadspdb.py prefix
 """
+
 
 import numpy as np
 import sys, glob
@@ -19,6 +21,7 @@ from ipi.engine.cell import Cell
 from ipi.utils.depend import *
 from ipi.utils.units import *
 
+
 def main(prefix):
 
    ipos=[]
@@ -27,12 +30,12 @@ def main(prefix):
       imode.append(filename.split(".")[-1])
       ipos.append(open(filename,"r"))
 
-   nbeads = len(ipos)   
+   nbeads = len(ipos)
    natoms = 0
    ifr = 0
    while True:
       try:
-         
+
          for i in range(nbeads):
             if (imode[i]=="xyz"):
                pos=read_file(imode[i],ipos[i])
@@ -42,7 +45,7 @@ def main(prefix):
             if natoms == 0:
                natoms = pos.natoms
                atoms = Atoms(natoms)
-            
+
             atoms.q += pos.q
             atoms.names = pos.names
       except EOFError: # finished reading files

--- a/tools/py/posforce2kinetic.py
+++ b/tools/py/posforce2kinetic.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 """ posforce2kinetic.py
 
 Reads positions and forces from an i-PI run and computes the
@@ -14,6 +15,7 @@ Syntax:
    posforce2kinetic.py prefix temperature[K]
 """
 
+
 import numpy as np
 import sys
 import glob
@@ -21,6 +23,7 @@ from ipi.utils.io import read_file
 from ipi.engine.beads import Beads
 from ipi.utils.depend import *
 from ipi.utils.units import *
+
 
 def main(prefix, temp):
 

--- a/tools/py/trimsim.py
+++ b/tools/py/trimsim.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 """ trimsim.py
 
 Relies on the infrastructure of i-pi, so the ipi package should
@@ -17,6 +18,7 @@ will be output.
 Syntax:
    trimsim.py inputfile.xml
 """
+
 
 import sys
 import os
@@ -165,6 +167,7 @@ def main(inputfile, outdir="trim"):
                      traj[isys]["ofile"].write(''.join(ibuffer))
       except EOFError:
          break
+
 
 if __name__ == '__main__':
    main(*sys.argv[1:])

--- a/tools/py/xyz2pdb.py
+++ b/tools/py/xyz2pdb.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 """ mergebeadspdb.py
 
 Reads positions of individual beads from an i-PI run and
@@ -31,7 +32,7 @@ def main(filename):
          cell.array_pbc(pos.q)
       except EOFError: # finished reading files
          sys.exit(0)
-      
+
       print_file("pdb", pos, cell)
       ifr+=1
 


### PR DESCRIPTION
The Python interpreter should not be hard coded to `/usr/bin/python`, but rather given by the run-time environment.

Some blank lines added as a bonus and trailing white space removed, courtesy of vim automation.
