### PR TITLE
[WIP] Added an example driver for dynamics, do NOT merge

### DIFF
--- a/ipi/engine/motion/__init__.py
+++ b/ipi/engine/motion/__init__.py
@@ -15,3 +15,4 @@ from .neb import NEBMover
 from .phonons import DynMatrixMover
 from .multi import MultiMotion
 from .alchemy import AlchemyMC
+from .displace import Displace

--- a/ipi/engine/motion/displace.py
+++ b/ipi/engine/motion/displace.py
@@ -1,0 +1,56 @@
+# This file is part of i-PI.
+# i-PI Copyright (C) 2014-2015 i-PI developers
+# See the "licenses" directory for full license information.
+
+import time
+import numpy as np
+
+from ipi.engine.motion import Motion
+from ipi.utils.softexit import softexit
+from ipi.utils.io import read_file
+from ipi.utils.io.inputs.io_xml import xml_parse_file
+from ipi.utils.units import unit_to_internal
+
+
+__all__ = ['Displace']
+
+
+class Displace(Motion):
+    """Calculator object that just displaces all non-fixed atoms by a specific amount for each step
+
+    Attributes:
+        dv: the rigid displacement vector
+
+    Depend objects:
+        None really meaningful.
+    """
+
+    def __init__(self, fixcom=False, fixatoms=None, displacement=None):
+        """Initialises Replay.
+
+        Args:
+           temp: The system temperature.
+           fixcom: An optional boolean which decides whether the centre of mass
+              motion will be constrained or not. Defaults to False.
+           displacement: displacement vector of coordinates
+        """
+        super(Displace, self).__init__(fixcom=fixcom, fixatoms=fixatoms)
+        if displacement is None:
+            raise ValueError("Must provide a displacement vector")
+        self.displacement = displacement
+        if self.displacement.size != 3:
+            raise ValueError("Displacement vector must be 3 values")
+
+    def bind(self, ens, beads, nm, cell, bforce, prng):
+        super(Displace, self).bind(ens, beads, nm, cell, bforce, prng)
+
+    def step(self, step=None):
+        """Step the displacement."""
+        if step is None:
+            softexit.trigger("Unknown step count. Exiting simulation")
+            return
+
+        for bead in self.beads:
+            # To get correct displacement of all atoms
+            n = bead.q.size / 3
+            bead.q += np.tile(self.displacement, n)

--- a/ipi/engine/motion/displace.py
+++ b/ipi/engine/motion/displace.py
@@ -5,11 +5,9 @@
 import time
 import numpy as np
 
+from ipi.utils.depend import dstrip
 from ipi.engine.motion import Motion
 from ipi.utils.softexit import softexit
-from ipi.utils.io import read_file
-from ipi.utils.io.inputs.io_xml import xml_parse_file
-from ipi.utils.units import unit_to_internal
 
 
 __all__ = ['Displace']
@@ -50,7 +48,8 @@ class Displace(Motion):
             softexit.trigger("Unknown step count. Exiting simulation")
             return
 
-        for bead in self.beads:
+        for i, bead in enumerate(self.beads):
+            f = dstrip(self.forces.f[i]).reshape(-1, 3)
             # To get correct displacement of all atoms
             n = bead.q.size / 3
             bead.q += np.tile(self.displacement, n)

--- a/ipi/inputs/motion/displace.py
+++ b/ipi/inputs/motion/displace.py
@@ -1,0 +1,61 @@
+"""Deals with creating the ensembles class.
+
+Copyright (C) 2013, Joshua More and Michele Ceriotti
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http.//www.gnu.org/licenses/>.
+
+Inputs created by Michele Ceriotti and Benjamin Helfrecht, 2015
+
+Classes:
+   InputGeop: Deals with creating the Geop object from a file, and
+      writing the checkpoints.
+"""
+
+import numpy as np
+import ipi.engine.initializer
+from ipi.engine.motion import *
+from ipi.utils.inputvalue import *
+from ipi.inputs.initializer import *
+from ipi.utils.units import *
+
+__all__ = ["InputDisplace"]
+
+
+class InputDisplace(InputDictionary):
+    """Direct displacement calculation options."""
+
+    attribs = {}
+    fields = {
+        "displacement": (InputArray, {"dtype": float,
+                                      "default": np.zeros(3, float),
+                                      "dimension": "length",
+                                      "help": "The displacement for each step.",
+        }),
+    }
+
+    default_help = "Constant displacements of the non-fixed atoms."
+    default_label = "DISPLACE"
+
+    def store(self, displace):
+        """ Store an `Displace` instance in a minimal representation
+
+        Parameters
+        ----------
+        displace : Displace
+           object
+        """
+        if displace == {}:
+            return
+
+        self.displacement.store(displace.displacement)


### PR DESCRIPTION
This is meant as an exercise on adding new motion classes (it SHOULDN'T be merged).

I have checked it works with Siesta and I can retrieve and
send forces/coordinates.

These are notes taken during the development of this PR.
The PR is not meant as an actual PR but rather to inform the developers of
problems related to the development of new motion classes.

Here are my "random" thoughts while developing a new `Motion` class. Please do not take
them as critisicms!

1. When adding a motion class it is unclear which methods are required for
   a fully functioning motion class.

2. The dependency scheme is smart, but since the documentation of this is
   low it is extremely difficult to figure out how to structure the new `Motion`
   class. I.e. a call-graph with method names would be really helpful.
   Fig. 1.2 and 1.3 seems to document the dependency scheme. But not for developers.

   Also, in the dependency scheme how does it now that new values have entered?
   I.e. when is the cached value reset and how does ipi track this information?

3. It seems that adding a new motion class also requires a new `InputMotion` class
   to accompany it (if variable inputs are required). The structure of the Input* class
   is also un-documented.

   3a) An idea, would it make sense to automatically populate the .fields in the Input*
       classes by looping and checking their inheritance?
       Currently this does not work because the `InputDynamics` is not sub-classed from `InputMotionBase`/`InputMotion`,
       but I guess some kind of higher class based scheme could be used to automate some of
       the lists?

4. Input* classes and their corresponding engine classes seems to be highly connected.
   The engines are passed as arguments to the Input.store method (something that is not entirely
   clear from the documentation). But it seems to me that the input class should feed data
   to the engine class (is this done in `Simulation`?).
   This seems a bit backwards at a first glance. I would suspect input to return a simulation
   class, ready to be used?

5. When running a calculation there is _very_ little help if the input.xml is badly formatted.
   I.e. you would simply get an error message like this:

       File "/opt/python/2.7.14/gnu-7.3.0/bin/i-pi", line 4, in <module>
         __import__('pkg_resources').run_script('i-PI==1.0', 'i-pi')
       File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 750, in run_script
       File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 1527, in run_script
       File "/opt/python/2.7.14/gnu-7.3.0/lib/python2.7/site-packages/i_PI-1.0-py2.7.egg/EGG-INFO/scripts/i-pi", line 101, in <module>
         main(args[0], options.do_yappi)
       File "/opt/python/2.7.14/gnu-7.3.0/lib/python2.7/site-packages/i_PI-1.0-py2.7.egg/EGG-INFO/scripts/i-pi", line 48, in main
         simulation = Simulation.load_from_xml(fn_input, request_banner=True)
       File "/opt/python/2.7.14/gnu-7.3.0/lib/python2.7/site-packages/i_PI-1.0-py2.7.egg/ipi/engine/simulation.py", line 78, in load_from_xml
         input_simulation.parse(xmlrestart.fields[0][1])
       File "/opt/python/2.7.14/gnu-7.3.0/lib/python2.7/site-packages/i_PI-1.0-py2.7.egg/ipi/utils/inputvalue.py", line 338, in parse
         self.extend(f, v)
       File "/opt/python/2.7.14/gnu-7.3.0/lib/python2.7/site-packages/i_PI-1.0-py2.7.egg/ipi/utils/inputvalue.py", line 236, in extend
         raise ValueError("Error parsing " + name + " from " + str(xml))
       ValueError: Error parsing system from <ipi.utils.io.inputs.io_xml.xml_node object at 0x2b0c1bf2bf50>

   This small change would probably help (a little):

       diff --git a/ipi/utils/inputvalue.py b/ipi/utils/inputvalue.py
       index 4e31e63c..c5c22b84 100644
       --- a/ipi/utils/inputvalue.py
       +++ b/ipi/utils/inputvalue.py
       @@ -232,7 +232,10 @@ class Input(object):
		try:
		    newfield = self.dynamic[name][0](**self.dynamic[name][1])
		    newfield.parse(xml)
       -        except:
       +        except Exception as e:
       +            print(e)
       +            print('XML.node: {0}'.format(xml.name))
       +            print('  attribs: {0}'.format(xml.attribs))
		    raise ValueError("Error parsing " + name + " from " + str(xml))
		self.extra.append((name, newfield))

   however an extended help would be even better (for instance all variables have
   a help in their Input* definitions, so one could print out these in case of an
   error?

6. The unit only allow atomic_unit, however, wouldn't it make sense to allow `Bohr` as a unit-specification?
   Since `Angstrom` is an allowed unit-specification.

7. Lastly, while all this development is not too difficult (once the initial barrier has been hurdled) it
   would be very nice if one could make i-PI import plugins. I.e. something like

       <motion mode='plugin'>
          <plugin module="myexternal.package" class="MyClass"
               input_module="myexternal.package" input_class="MyInputClass"/>
       </motion>

   this would allow a fixed i-PI installation and allow easier hooks for external use.
   There are several choices regarding plugins, but this was just a basic idea.